### PR TITLE
quick fix for a decode bug, when using non ascii filenames

### DIFF
--- a/make_iiif.py
+++ b/make_iiif.py
@@ -43,7 +43,10 @@ def addCanvasToManifest(manifest,canvas,config,image,ic):
     canvas['label'] = label
     canvas['images'][0]['resource']['label'] = label
     # set service
-    canvas['images'][0]['resource']['service']['@id'] = config['baseurl']+"/"+image
+    try:
+        canvas['images'][0]['resource']['service']['@id'] = config['baseurl']+"/"+image
+    except UnicodeDecodeError:
+        canvas['images'][0]['resource']['service']['@id'] = config['baseurl']+"/"+image.decode('utf-8')
     # append canvas to manifest
     manifest['sequences'][0]['canvases'].append(canvas)
     return manifest


### PR DESCRIPTION
Sometimes, one gets a UnicodeDecodeError, like:

> Traceback (most recent call last):
  File "./make_iiif.py", line 71, in <module>
    manifest = addCanvasToManifest(manifest,canvas,config,image,ic)
  File "./make_iiif.py", line 48, in addCanvasToManifest
    canvas['images'][0]['resource']['service']['@id'] =
    config['baseurl']+"/"+image
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 46:
    ordinal not in range(128)

This fix will try to decode 'UTF-8' filenames, might fail with other
encodings, still.